### PR TITLE
Updated party.test.ts to use mongo memory server

### DIFF
--- a/api/tests/models/party.test.ts
+++ b/api/tests/models/party.test.ts
@@ -1,9 +1,27 @@
 import { Party, IParty } from '../../src/models/party';
-import '../../src/db/mongoose';
 import { ObjectId } from 'mongodb';
+import { MongoMemoryServer } from "mongodb-memory-server";
+import * as mongoose from "mongoose";
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = new MongoMemoryServer();
+  const mongoUri = await mongoServer.getUri();
+  await mongoose
+    .connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true })
+    .then()
+    .catch(() => console.error('Unable to connect to MongoDB'));
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
 
 afterEach(async () => {
-  await Party.remove({});
+  await Party.deleteMany({});
 });
 
 describe('Party model tests', () => {


### PR DESCRIPTION
I have updated the test files so that we now use the mongo-memory-server and I have removed the test containers. This has halved the build time to around 30s.